### PR TITLE
Add docs section with searchable page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # LLMLearning
-Learning live knowledge of AI/LLM with AI 
+
+This repository stores knowledge resources in the `docs/` folder. You can add PDF or Markdown files to that folder and list them in `docs/files.json` so they appear on the search page.
+
+Open `docs/index.html` in a browser to view and search the available documents.

--- a/docs/files.json
+++ b/docs/files.json
@@ -1,0 +1,4 @@
+[
+  {"name": "sample.md", "path": "sample.md"},
+  {"name": "sample.pdf", "path": "sample.pdf"}
+]

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Knowledge Base</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 40px; }
+#search { margin-bottom: 20px; padding: 8px; width: 300px; }
+</style>
+</head>
+<body>
+<h1>Knowledge Base</h1>
+<input type="text" id="search" placeholder="Search documents...">
+<ul id="fileList"></ul>
+<script>
+fetch('files.json')
+  .then(response => response.json())
+  .then(files => {
+    const list = document.getElementById('fileList');
+    files.forEach(f => {
+      const li = document.createElement('li');
+      const link = document.createElement('a');
+      link.href = f.path;
+      link.textContent = f.name;
+      li.appendChild(link);
+      list.appendChild(li);
+    });
+  });
+
+document.getElementById('search').addEventListener('input', function() {
+  const query = this.value.toLowerCase();
+  document.querySelectorAll('#fileList li').forEach(li => {
+    li.style.display = li.textContent.toLowerCase().includes(query) ? '' : 'none';
+  });
+});
+</script>
+</body>
+</html>

--- a/docs/sample.md
+++ b/docs/sample.md
@@ -1,0 +1,1 @@
+# Sample Document\nThis is a sample Markdown file.

--- a/docs/sample.pdf
+++ b/docs/sample.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Hello PDF) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000056 00000 n 
+0000000105 00000 n 
+0000000201 00000 n 
+0000000300 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+349
+%%EOF


### PR DESCRIPTION
## Summary
- add `docs` folder for storing files
- create a simple HTML viewer with search
- include sample markdown and PDF files
- update README with usage instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688b17650d508332b38f67f900b58a04